### PR TITLE
Update to remove default ports

### DIFF
--- a/deployment/install/microservices/openshift-configuration/auth-sso73-x509.yaml
+++ b/deployment/install/microservices/openshift-configuration/auth-sso73-x509.yaml
@@ -56,8 +56,8 @@ objects:
     name: ${APPLICATION_NAME}-postgresql
   spec:
     ports:
-    - port: 5432
-      targetPort: 5432
+    - port: 5532
+      targetPort: 5532
       name: tcp-postgres
     selector:
       deploymentConfig: ${APPLICATION_NAME}-postgresql
@@ -169,7 +169,7 @@ objects:
           - containerPort: 8778
             name: jolokia
             protocol: TCP
-          - containerPort: 8080
+          - containerPort: 9090
             name: http
             protocol: TCP
           - containerPort: 8443


### PR DESCRIPTION
According to a recent report default port usages must be avoided: https://www.bleepingcomputer.com/news/security/most-cyber-attacks-focus-on-just-three-tcp-ports/#:~:text=According%20to%20the%20report%2C%20the,(Hypertext%20Transfer%20Protocol%20Secure)

What should happen?
Default ports should be avoided

What happens instead?
Default ports are used